### PR TITLE
Setup matrix of Android branches

### DIFF
--- a/.github/actions/setup-cuttlefish/action.yml
+++ b/.github/actions/setup-cuttlefish/action.yml
@@ -92,6 +92,7 @@ runs:
           jq -r ".targets[] | select(.name == \"$TARGET\") | .last_known_good_build")
         echo "BUILD_ID=$BUILD_ID" >> $GITHUB_OUTPUT
         echo "BUILD_ID=$BUILD_ID" >> $GITHUB_ENV
+        echo "BRANCH=$BRANCH" >> $GITHUB_OUTPUT
         echo "CF_HOME=$HOME/cuttlefish" >> $GITHUB_ENV
 
     - name: Cache Android images
@@ -99,7 +100,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/cuttlefish-downloads
-        key: android-images-${{ steps.build-id.outputs.BUILD_ID }}
+        key: android-images-${{ steps.build-id.outputs.BRANCH }}-${{ steps.build-id.outputs.BUILD_ID }}
 
     - name: Download Android images
       if: steps.cache-images.outputs.cache-hit != 'true'

--- a/.github/actions/setup-cuttlefish/action.yml
+++ b/.github/actions/setup-cuttlefish/action.yml
@@ -17,7 +17,7 @@ inputs:
   memory-mb:
     description: 'Memory allocation for the emulator in MB'
     required: false
-    default: '8192'
+    default: '4096'
   cpus:
     description: 'Number of CPUs to allocate (default: all available)'
     required: false

--- a/.github/actions/setup-cuttlefish/action.yml
+++ b/.github/actions/setup-cuttlefish/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: 'Number of CPUs to allocate (default: all available)'
     required: false
     default: '0'
+  gpu-mode:
+    description: 'GPU mode (auto, drm_virgl, gfxstream, guest_swiftshader)'
+    required: false
+    default: 'guest_swiftshader'
 
 outputs:
   build-id:
@@ -116,7 +120,8 @@ runs:
         fi
         
         sg kvm -c "sg cvdnetwork -c 'HOME=$HOME/cuttlefish $HOME/cuttlefish/bin/launch_cvd \
-          -daemon -enable_sandbox=false -memory_mb=${{ inputs.memory-mb }} -cpus=$CPUS -report_anonymous_usage_stats=n'"
+          -daemon -enable_sandbox=false -memory_mb=${{ inputs.memory-mb }} -cpus=$CPUS \
+          -gpu_mode=${{ inputs.gpu-mode }} -report_anonymous_usage_stats=n'"
         
         adb wait-for-device
         

--- a/.github/actions/setup-cuttlefish/action.yml
+++ b/.github/actions/setup-cuttlefish/action.yml
@@ -6,14 +6,10 @@ inputs:
     description: 'Cuttlefish version tag (e.g., v1.32.0)'
     required: false
     default: 'v1.32.0'
-  api-level:
-    description: 'Android API level (e.g., 35, 36, 36.1)'
-    required: false
-    default: '36'
   android-branch:
-    description: 'Android branch to download (e.g., aosp-android-latest-release). If not specified, derived from api-level'
+    description: 'Android branch to download (e.g., aosp-android-latest-release, aosp-android14-gsi, aosp-android15-gsi)'
     required: false
-    default: ''
+    default: 'aosp-android-latest-release'
   android-device:
     description: 'Android device type (e.g., aosp_cf_x86_64_only_phone)'
     required: false
@@ -75,16 +71,7 @@ runs:
       id: build-id
       shell: bash
       run: |
-        # Determine the Android branch based on api-level if android-branch is not provided
-        if [ -z "${{ inputs.android-branch }}" ]; then
-          API_LEVEL="${{ inputs.api-level }}"
-          # Remove any decimal points for branch name (e.g., 36.1 -> 361)
-          API_LEVEL_CLEAN=$(echo "$API_LEVEL" | tr -d '.')
-          BRANCH="aosp-android${API_LEVEL_CLEAN}-release"
-        else
-          BRANCH="${{ inputs.android-branch }}"
-        fi
-        
+        BRANCH="${{ inputs.android-branch }}"
         echo "Using Android branch: $BRANCH"
         
         TARGET="${{ inputs.android-device }}-userdebug"

--- a/.github/actions/setup-cuttlefish/action.yml
+++ b/.github/actions/setup-cuttlefish/action.yml
@@ -119,9 +119,17 @@ runs:
           CPUS=$(nproc)
         fi
         
+        # Older Android versions don't support all flags
+        BRANCH="${{ inputs.android-branch }}"
+        if [[ "$BRANCH" == "aosp-android14-gsi" || "$BRANCH" == "aosp-android-latest-release" ]]; then
+          EXTRA_FLAGS="-enable_sandbox=false -report_anonymous_usage_stats=n"
+        else
+          EXTRA_FLAGS=""
+        fi
+        
         sg kvm -c "sg cvdnetwork -c 'HOME=$HOME/cuttlefish $HOME/cuttlefish/bin/launch_cvd \
-          -daemon -enable_sandbox=false -memory_mb=${{ inputs.memory-mb }} -cpus=$CPUS \
-          -gpu_mode=${{ inputs.gpu-mode }} -report_anonymous_usage_stats=n'"
+          -daemon -memory_mb=${{ inputs.memory-mb }} -cpus=$CPUS \
+          -gpu_mode=${{ inputs.gpu-mode }} $EXTRA_FLAGS'"
         
         adb wait-for-device
         

--- a/.github/actions/setup-cuttlefish/action.yml
+++ b/.github/actions/setup-cuttlefish/action.yml
@@ -6,10 +6,14 @@ inputs:
     description: 'Cuttlefish version tag (e.g., v1.32.0)'
     required: false
     default: 'v1.32.0'
-  android-branch:
-    description: 'Android branch to download (e.g., aosp-android-latest-release)'
+  api-level:
+    description: 'Android API level (e.g., 35, 36, 36.1)'
     required: false
-    default: 'aosp-android-latest-release'
+    default: '36'
+  android-branch:
+    description: 'Android branch to download (e.g., aosp-android-latest-release). If not specified, derived from api-level'
+    required: false
+    default: ''
   android-device:
     description: 'Android device type (e.g., aosp_cf_x86_64_only_phone)'
     required: false
@@ -71,8 +75,20 @@ runs:
       id: build-id
       shell: bash
       run: |
+        # Determine the Android branch based on api-level if android-branch is not provided
+        if [ -z "${{ inputs.android-branch }}" ]; then
+          API_LEVEL="${{ inputs.api-level }}"
+          # Remove any decimal points for branch name (e.g., 36.1 -> 361)
+          API_LEVEL_CLEAN=$(echo "$API_LEVEL" | tr -d '.')
+          BRANCH="aosp-android${API_LEVEL_CLEAN}-release"
+        else
+          BRANCH="${{ inputs.android-branch }}"
+        fi
+        
+        echo "Using Android branch: $BRANCH"
+        
         TARGET="${{ inputs.android-device }}-userdebug"
-        BUILD_ID=$(curl -sL "https://ci.android.com/builds/branches/${{ inputs.android-branch }}/status.json" | \
+        BUILD_ID=$(curl -sL "https://ci.android.com/builds/branches/${BRANCH}/status.json" | \
           jq -r ".targets[] | select(.name == \"$TARGET\") | .last_known_good_build")
         echo "BUILD_ID=$BUILD_ID" >> $GITHUB_OUTPUT
         echo "BUILD_ID=$BUILD_ID" >> $GITHUB_ENV

--- a/.github/actions/setup-cuttlefish/action.yml
+++ b/.github/actions/setup-cuttlefish/action.yml
@@ -119,17 +119,10 @@ runs:
           CPUS=$(nproc)
         fi
         
-        # Older Android versions don't support all flags
-        BRANCH="${{ inputs.android-branch }}"
-        if [[ "$BRANCH" == "aosp-android14-gsi" || "$BRANCH" == "aosp-android-latest-release" ]]; then
-          EXTRA_FLAGS="-enable_sandbox=false -report_anonymous_usage_stats=n"
-        else
-          EXTRA_FLAGS=""
-        fi
-        
         sg kvm -c "sg cvdnetwork -c 'HOME=$HOME/cuttlefish $HOME/cuttlefish/bin/launch_cvd \
           -daemon -memory_mb=${{ inputs.memory-mb }} -cpus=$CPUS \
-          -gpu_mode=${{ inputs.gpu-mode }} $EXTRA_FLAGS'"
+          -gpu_mode=${{ inputs.gpu-mode }} \
+          -enable_sandbox=false -report_anonymous_usage_stats=n'"
         
         adb wait-for-device
         

--- a/.github/actions/setup-cuttlefish/action.yml
+++ b/.github/actions/setup-cuttlefish/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: false
     default: 'v1.32.0'
   android-branch:
-    description: 'Android branch to download (e.g., aosp-android-latest-release, aosp-android14-gsi, aosp-android15-gsi)'
+    description: 'Android branch to download (e.g., aosp-android-latest-release, aosp-android14-gsi)'
     required: false
     default: 'aosp-android-latest-release'
   android-device:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         android-branch:
-          - aosp-android11-gsi           # API 30
-          - aosp-android12-gsi           # API 31-32
-          - aosp-android13-gsi           # API 33
           - aosp-android14-gsi           # API 34
           - aosp-android-latest-release  # API 36-36.1
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           cuttlefish-version: v1.32.0
           android-branch: ${{ matrix.android-branch }}
           android-device: aosp_cf_x86_64_only_phone
-          memory-mb: 8192
+          memory-mb: 4096
 
       - name: Build and run app
         uses: ./.github/actions/build-app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
 jobs:
   boot-cuttlefish:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        api-level: [30, 31, 32, 33, 34, 35, 36, '36.1']
     
     steps:
       - uses: actions/checkout@v4
@@ -21,7 +25,7 @@ jobs:
         uses: ./.github/actions/setup-cuttlefish
         with:
           cuttlefish-version: v1.32.0
-          android-branch: aosp-android-latest-release
+          api-level: ${{ matrix.api-level }}
           android-device: aosp_cf_x86_64_only_phone
           memory-mb: 8192
 
@@ -43,7 +47,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: maui-app-screenshot
+          name: maui-app-screenshot-api-${{ matrix.api-level }}
           path: screenshots/maui-app-screenshot.png
           retention-days: 30
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-level: [30, 31, 32, 33, 34, 35, 36, '36.1']
+        android-branch:
+          - aosp-android11-gsi           # API 30
+          - aosp-android12-gsi           # API 31-32
+          - aosp-android13-gsi           # API 33
+          - aosp-android14-gsi           # API 34
+          - aosp-android-latest-release  # API 36-36.1
     
     steps:
       - uses: actions/checkout@v4
@@ -25,7 +30,7 @@ jobs:
         uses: ./.github/actions/setup-cuttlefish
         with:
           cuttlefish-version: v1.32.0
-          api-level: ${{ matrix.api-level }}
+          android-branch: ${{ matrix.android-branch }}
           android-device: aosp_cf_x86_64_only_phone
           memory-mb: 8192
 
@@ -47,7 +52,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: maui-app-screenshot-api-${{ matrix.api-level }}
+          name: maui-app-screenshot-${{ matrix.android-branch }}
           path: screenshots/maui-app-screenshot.png
           retention-days: 30
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -28,7 +28,7 @@ jobs:
           cuttlefish-version: v1.32.0
           android-branch: aosp-android-latest-release
           android-device: aosp_cf_x86_64_only_phone
-          memory-mb: 8192
+          memory-mb: 4096
 
       - name: Build app
         uses: ./.github/actions/build-app

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Sets up and starts the Cuttlefish emulator. Located at `.github/actions/setup-cu
 - `cuttlefish-version` (optional, default: `v1.32.0`) - Cuttlefish version tag
 - `android-branch` (optional, default: `aosp-android-latest-release`) - Android branch to download
 - `android-device` (optional, default: `aosp_cf_x86_64_only_phone`) - Android device type
-- `memory-mb` (optional, default: `8192`) - Memory allocation in MB
+- `memory-mb` (optional, default: `4096`) - Memory allocation in MB
 - `cpus` (optional, default: `0` = all available) - Number of CPUs to allocate
 
 **Outputs:**
@@ -47,7 +47,7 @@ Sets up and starts the Cuttlefish emulator. Located at `.github/actions/setup-cu
     cuttlefish-version: v1.32.0
     android-branch: aosp-android-latest-release
     android-device: aosp_cf_x86_64_only_phone
-    memory-mb: 8192
+    memory-mb: 4096
 ```
 
 ### stop-cuttlefish

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Sets up and starts the Cuttlefish emulator. Located at `.github/actions/setup-cu
 **Inputs:**
 - `cuttlefish-version` (optional, default: `v1.32.0`) - Cuttlefish version tag
 - `android-branch` (optional, default: `aosp-android-latest-release`) - Android branch to download
+  - Supported branches: `aosp-android14-gsi` (API 34), `aosp-android-latest-release` (API 36+)
+  - Note: Older branches (android11-13) crash GitHub Actions runners and require further investigation
 - `android-device` (optional, default: `aosp_cf_x86_64_only_phone`) - Android device type
 - `memory-mb` (optional, default: `4096`) - Memory allocation in MB
 - `cpus` (optional, default: `0` = all available) - Number of CPUs to allocate


### PR DESCRIPTION
This pull request updates the Cuttlefish emulator setup in CI workflows to support multiple Android branches and improve resource usage. The main changes include adding matrix support for different Android branches, lowering the default memory allocation, and introducing GPU mode configuration. These updates enhance compatibility and efficiency for CI runs.

**CI Workflow Improvements:**
* Added matrix strategy in `.github/workflows/ci.yml` to run tests against both `aosp-android14-gsi` (API 34) and `aosp-android-latest-release` (API 36+) branches, increasing test coverage and compatibility.
* Updated artifact naming in `.github/workflows/ci.yml` to include the Android branch, making it easier to distinguish results from different branches.

**Cuttlefish Emulator Configuration:**
* Lowered the default memory allocation for the emulator from 8192 MB to 4096 MB in `.github/actions/setup-cuttlefish/action.yml`, `.github/workflows/ci.yml`, `.github/workflows/copilot-setup-steps.yml`, and documentation, reducing resource usage and improving reliability on GitHub Actions runners. [[1]](diffhunk://#diff-d5b8880f4d8d941733c0ef73815621f5a5b9f428c705eb9c885ca3e0c7e6c455L20-R28) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL24-R32) [[3]](diffhunk://#diff-98dad98422cf59793a353f9b6bfe6a129977e92af3d5b4e38f98ae45bcb7560dL31-R31) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R35-R38) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L50-R52)
* Added a new `gpu-mode` input to `.github/actions/setup-cuttlefish/action.yml` with configurable options (auto, drm_virgl, gfxstream, guest_swiftshader), allowing more flexibility in emulator graphics configuration. [[1]](diffhunk://#diff-d5b8880f4d8d941733c0ef73815621f5a5b9f428c705eb9c885ca3e0c7e6c455L20-R28) [[2]](diffhunk://#diff-d5b8880f4d8d941733c0ef73815621f5a5b9f428c705eb9c885ca3e0c7e6c455L115-R125)

**Documentation Updates:**
* Clarified supported Android branches and explained issues with older branches in the Cuttlefish action documentation (`README.md`).

**Caching and Build Logic:**
* Improved caching logic in `.github/actions/setup-cuttlefish/action.yml` to use both branch and build ID for cache keys, preventing cross-branch cache collisions.

These changes collectively make CI runs more robust, resource-efficient, and easier to debug across different Android versions.